### PR TITLE
feat: Can ignore importing the RequestContextModule

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,9 +1,12 @@
-name: Check Pull Request
+name: Build
 
 on:
   pull_request:
     branches:
       - master
+      - beta
+      - alpha
+      - "*.x"
 
 jobs:
   build:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,37 @@
+name: Lint
+
+on:
+  pull_request:
+    branches:
+      - master
+      - beta
+      - alpha
+      - "*.x"
+
+jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v1
+        with:
+          node-version: 18
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v2
+        id: pnpm-install
+        with:
+          version: 8
+          run_install: |
+            - recursive: true
+              args: [--frozen-lockfile]
+
+      - name: Build
+        run: pnpm run build
+
+      - name: Lint
+        run: pnpm run lint

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -1,14 +1,13 @@
-name: GitHub Pages
+name: Website
 
 on:
   push:
     branches:
-      - main
-      - beta
-      - alpha
+      - master
 
 jobs:
   deploy:
+    name: Deploy
     runs-on: ubuntu-22.04
     permissions:
       contents: write

--- a/examples/graphql/src/app.module.ts
+++ b/examples/graphql/src/app.module.ts
@@ -2,7 +2,6 @@ import { EntityManager, PostgreSqlDriver } from "@mikro-orm/postgresql";
 import { DatabaseModule } from "@nest-boot/database";
 import { GraphQLModule } from "@nest-boot/graphql";
 import { LoggerModule } from "@nest-boot/logger";
-import { RequestContextModule } from "@nest-boot/request-context";
 import { SearchModule } from "@nest-boot/search";
 import { PostgresqlSearchEngine } from "@nest-boot/search-engine-postgresql";
 import { Module } from "@nestjs/common";
@@ -52,7 +51,6 @@ const GraphQLDynamicModule = GraphQLModule.forRootAsync({
   imports: [
     ConfigDynamicModule,
     LoggerModule,
-    RequestContextModule,
     DatabaseDynamicModule,
     SearchDynamicModule,
     GraphQLDynamicModule,

--- a/examples/repl/src/app.module.ts
+++ b/examples/repl/src/app.module.ts
@@ -1,7 +1,4 @@
-import { RequestContextModule } from "@nest-boot/request-context";
 import { Module } from "@nestjs/common";
 
-@Module({
-  imports: [RequestContextModule],
-})
+@Module({})
 export class AppModule {}

--- a/examples/search-fulltext-with-postgresql/src/app.module.ts
+++ b/examples/search-fulltext-with-postgresql/src/app.module.ts
@@ -1,6 +1,5 @@
 import { EntityManager, PostgreSqlDriver } from "@mikro-orm/postgresql";
 import { DatabaseModule } from "@nest-boot/database";
-import { RequestContextModule } from "@nest-boot/request-context";
 import { SearchModule } from "@nest-boot/search";
 import { PostgresqlSearchEngine } from "@nest-boot/search-engine-postgresql";
 import { Module } from "@nestjs/common";
@@ -32,7 +31,6 @@ const SearchDynamicModule = SearchModule.registerAsync({
 @Module({
   imports: [
     ConfigDynamicModule,
-    RequestContextModule,
     DatabaseDynamicModule,
     SearchDynamicModule,
     PostModule,

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -28,6 +28,7 @@
     "@mikro-orm/nestjs": "^5.2.1",
     "@nest-boot/database": "workspace:*",
     "@nest-boot/eslint-config": "workspace:*",
+    "@nest-boot/eslint-plugin": "workspace:*",
     "@nest-boot/i18n": "workspace:*",
     "@nest-boot/request-context": "workspace:*",
     "@nest-boot/tsconfig": "workspace:*",

--- a/packages/auth/src/auth.module.ts
+++ b/packages/auth/src/auth.module.ts
@@ -1,3 +1,4 @@
+import { RequestContextModule } from "@nest-boot/request-context";
 import {
   Global,
   Inject,
@@ -18,6 +19,7 @@ import { AuthModuleOptions } from "./interfaces";
 
 @Global()
 @Module({
+  imports: [RequestContextModule],
   providers: [
     {
       provide: APP_GUARD,
@@ -31,7 +33,7 @@ import { AuthModuleOptions } from "./interfaces";
 export class AuthModule extends ConfigurableModuleClass implements NestModule {
   constructor(
     @Inject(MODULE_OPTIONS_TOKEN)
-    private readonly options: AuthModuleOptions
+    private readonly options: AuthModuleOptions,
   ) {
     super();
   }

--- a/packages/auth/src/interfaces/auth-module-options.interface.ts
+++ b/packages/auth/src/interfaces/auth-module-options.interface.ts
@@ -17,8 +17,8 @@ export interface AuthModuleOptions {
   defaultRequireAuth?: boolean;
 
   // 包含路由默认为 *
-  includeRoutes?: Array<string | Type<any> | RouteInfo>;
+  includeRoutes?: (string | Type | RouteInfo)[];
 
   // 排除路由默认为空
-  excludeRoutes?: Array<string | RouteInfo>;
+  excludeRoutes?: (string | RouteInfo)[];
 }

--- a/packages/auth/src/utils/mixin-permissions.utils.ts
+++ b/packages/auth/src/utils/mixin-permissions.utils.ts
@@ -4,8 +4,8 @@ import { type HasPermissions } from "../interfaces";
 
 export type Type<T = any> = new (...args: any[]) => T;
 
-export function mixinPermissions<T extends Type<any>>(
-  base: T
+export function mixinPermissions<T extends Type>(
+  base: T,
 ): Type<HasPermissions> & T {
   const trait = class extends base implements HasPermissions {
     permissions: string[] = [];
@@ -13,7 +13,7 @@ export function mixinPermissions<T extends Type<any>>(
 
   Property({ type: t.array, onCreate: () => [] })(
     trait.prototype,
-    "permissions"
+    "permissions",
   );
 
   return trait;

--- a/packages/crypt/package.json
+++ b/packages/crypt/package.json
@@ -23,6 +23,7 @@
   },
   "devDependencies": {
     "@nest-boot/eslint-config": "workspace:*",
+    "@nest-boot/eslint-plugin": "workspace:*",
     "@nest-boot/tsconfig": "workspace:*",
     "@nestjs/common": "^10.2.5",
     "@nestjs/core": "^10.2.5",

--- a/packages/database/src/database.module.ts
+++ b/packages/database/src/database.module.ts
@@ -5,7 +5,10 @@ import {
   type MikroOrmModuleFeatureOptions,
 } from "@mikro-orm/nestjs";
 import { HealthCheckRegistry } from "@nest-boot/health-check";
-import { RequestContext } from "@nest-boot/request-context";
+import {
+  RequestContext,
+  RequestContextModule,
+} from "@nest-boot/request-context";
 import {
   type DynamicModule,
   Logger,
@@ -26,6 +29,7 @@ import { type DatabaseModuleOptions } from "./interfaces";
 import { withBaseConfig } from "./utils/with-base-config.util";
 
 @Module({
+  imports: [RequestContextModule],
   providers: [DatabaseHealthIndicator],
 })
 export class DatabaseModule

--- a/packages/database/src/interfaces/database-module-options.interface.ts
+++ b/packages/database/src/interfaces/database-module-options.interface.ts
@@ -1,3 +1,3 @@
 import { type MikroOrmModuleSyncOptions } from "@mikro-orm/nestjs";
 
-export interface DatabaseModuleOptions extends MikroOrmModuleSyncOptions {}
+export type DatabaseModuleOptions = MikroOrmModuleSyncOptions;

--- a/packages/database/src/migration-generator.ts
+++ b/packages/database/src/migration-generator.ts
@@ -8,7 +8,7 @@ export class MigrationGenerator extends TSMigrationGenerator {
 
     const formatSql = format(sql, { language: "postgresql" }).replace(
       /['\\]/g,
-      "\\'"
+      "\\'",
     );
 
     return `${padding}this.addSql(/* SQL */ \`
@@ -18,13 +18,14 @@ export class MigrationGenerator extends TSMigrationGenerator {
 
   generateMigrationFile(
     className: string,
-    diff: { up: string[]; down: string[] }
+    diff: { up: string[]; down: string[] },
   ): string {
+    // eslint-disable-next-line @typescript-eslint/no-base-to-string, @typescript-eslint/restrict-template-expressions
     return `/* eslint-disable */\n\n${prettier.format(
       super.generateMigrationFile(className, diff),
       {
         parser: "typescript",
-      }
+      },
     )}`;
   }
 }

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -8,7 +8,6 @@
     "build": "tsc",
     "clean": "rm -rf .turbo && rm -rf node_modules && rm -rf dist",
     "dev": "tsc --watch",
-    "lint": "npm-run-all \"lint:*\"",
     "lint:eslint-docs": "npm-run-all \"update:eslint-docs -- --check\"",
     "lint:js": "eslint .",
     "test": "mocha tests --recursive",

--- a/packages/event-emitter/src/event-emitter.module.ts
+++ b/packages/event-emitter/src/event-emitter.module.ts
@@ -1,3 +1,4 @@
+import { RequestContextModule } from "@nest-boot/request-context";
 import { DynamicModule, Module } from "@nestjs/common";
 import { DiscoveryModule } from "@nestjs/core";
 import { EventEmitter2 } from "eventemitter2";
@@ -6,7 +7,9 @@ import { EventSubscribersLoader } from "./event-subscribers.loader";
 import { EventsMetadataAccessor } from "./events-metadata.accessor";
 import { EventEmitterModuleOptions } from "./interfaces";
 
-@Module({})
+@Module({
+  imports: [RequestContextModule],
+})
 export class EventEmitterModule {
   static forRoot(options?: EventEmitterModuleOptions): DynamicModule {
     return {

--- a/packages/hash/package.json
+++ b/packages/hash/package.json
@@ -26,6 +26,7 @@
   },
   "devDependencies": {
     "@nest-boot/eslint-config": "workspace:*",
+    "@nest-boot/eslint-plugin": "workspace:*",
     "@nest-boot/tsconfig": "workspace:*",
     "@nestjs/common": "^10.2.5",
     "@nestjs/core": "^10.2.5",

--- a/packages/health-check/package.json
+++ b/packages/health-check/package.json
@@ -22,6 +22,7 @@
   },
   "devDependencies": {
     "@nest-boot/eslint-config": "workspace:*",
+    "@nest-boot/eslint-plugin": "workspace:*",
     "@nest-boot/tsconfig": "workspace:*",
     "@nestjs/common": "^10.2.5",
     "@nestjs/core": "^10.2.5",

--- a/packages/i18n/package.json
+++ b/packages/i18n/package.json
@@ -22,6 +22,7 @@
   },
   "devDependencies": {
     "@nest-boot/eslint-config": "workspace:*",
+    "@nest-boot/eslint-plugin": "workspace:*",
     "@nest-boot/request-context": "workspace:*",
     "@nest-boot/tsconfig": "workspace:*",
     "@nestjs/common": "^10.2.5",

--- a/packages/i18n/src/i18n.middleware.ts
+++ b/packages/i18n/src/i18n.middleware.ts
@@ -13,12 +13,12 @@ export class I18nMiddleware implements NestMiddleware {
   private readonly handler: Handler;
 
   constructor(
-    @Inject(MODULE_OPTIONS_TOKEN) readonly options: I18nModuleOptions
+    @Inject(MODULE_OPTIONS_TOKEN) readonly options: I18nModuleOptions,
   ) {
     this.handler = middleware.handle(i18next as any, options) as Handler;
   }
 
-  async use(req: Request, res: Response, next: () => void): Promise<void> {
+  use(req: Request, res: Response, next: () => void): void {
     this.handler(req, res, () => {
       RequestContext.set(I18N, req.i18n);
       next();

--- a/packages/i18n/src/i18n.module.ts
+++ b/packages/i18n/src/i18n.module.ts
@@ -1,3 +1,4 @@
+import { RequestContextModule } from "@nest-boot/request-context";
 import {
   type DynamicModule,
   type MiddlewareConsumer,
@@ -22,7 +23,9 @@ import { type I18nModuleOptions } from "./interfaces/i18n-module-options.interfa
 
 i18next.use(Backend).use(LanguageDetector);
 
-@Module({})
+@Module({
+  imports: [RequestContextModule],
+})
 export class I18nModule extends ConfigurableModuleClass implements NestModule {
   static register(options: typeof OPTIONS_TYPE): DynamicModule {
     return {
@@ -38,7 +41,7 @@ export class I18nModule extends ConfigurableModuleClass implements NestModule {
 
   private static with(
     options: typeof OPTIONS_TYPE | typeof ASYNC_OPTIONS_TYPE,
-    dynamicModule: DynamicModule
+    dynamicModule: DynamicModule,
   ): DynamicModule {
     const provider: Provider<i18n> = {
       provide: I18N,

--- a/packages/i18n/src/interfaces/i18n-module-options.interface.ts
+++ b/packages/i18n/src/interfaces/i18n-module-options.interface.ts
@@ -1,3 +1,3 @@
 import { type InitOptions } from "i18next";
 
-export interface I18nModuleOptions extends InitOptions {}
+export type I18nModuleOptions = InitOptions;

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -31,6 +31,7 @@
   },
   "devDependencies": {
     "@nest-boot/eslint-config": "workspace:*",
+    "@nest-boot/eslint-plugin": "workspace:*",
     "@nest-boot/request-context": "workspace:*",
     "@nest-boot/tsconfig": "workspace:*",
     "@nestjs/common": "^10.2.5",

--- a/packages/logger/src/logger-module-options.interface.ts
+++ b/packages/logger/src/logger-module-options.interface.ts
@@ -1,3 +1,3 @@
 import { type Options } from "pino-http";
 
-export interface LoggerModuleOptions extends Options {}
+export type LoggerModuleOptions = Options;

--- a/packages/logger/src/logger.module.ts
+++ b/packages/logger/src/logger.module.ts
@@ -1,4 +1,9 @@
-import { REQUEST, RequestContext, RESPONSE } from "@nest-boot/request-context";
+import {
+  REQUEST,
+  RequestContext,
+  RequestContextModule,
+  RESPONSE,
+} from "@nest-boot/request-context";
 import {
   Global,
   Inject,
@@ -24,6 +29,7 @@ import { LoggerModuleOptions } from "./logger-module-options.interface";
 
 @Global()
 @Module({
+  imports: [RequestContextModule],
   providers: [
     Logger,
     {

--- a/packages/mailer/package.json
+++ b/packages/mailer/package.json
@@ -23,6 +23,7 @@
   },
   "devDependencies": {
     "@nest-boot/eslint-config": "workspace:*",
+    "@nest-boot/eslint-plugin": "workspace:*",
     "@nest-boot/tsconfig": "workspace:*",
     "@nestjs/common": "^10.2.5",
     "@nestjs/core": "^10.2.5",

--- a/packages/metrics/package.json
+++ b/packages/metrics/package.json
@@ -23,6 +23,7 @@
   },
   "devDependencies": {
     "@nest-boot/eslint-config": "workspace:*",
+    "@nest-boot/eslint-plugin": "workspace:*",
     "@nest-boot/tsconfig": "workspace:*",
     "@nestjs/common": "^10.2.5",
     "@nestjs/core": "^10.2.5",

--- a/packages/queue/src/queue-core.module.ts
+++ b/packages/queue/src/queue-core.module.ts
@@ -1,3 +1,4 @@
+import { RequestContextModule } from "@nest-boot/request-context";
 import { Global, Logger, Module } from "@nestjs/common";
 import { DiscoveryService, MetadataScanner } from "@nestjs/core";
 
@@ -6,6 +7,7 @@ import { QueueManager } from "./queue.manager";
 
 @Global()
 @Module({
+  imports: [RequestContextModule],
   providers: [
     DiscoveryService,
     MetadataScanner,

--- a/packages/redis/package.json
+++ b/packages/redis/package.json
@@ -22,6 +22,7 @@
   },
   "devDependencies": {
     "@nest-boot/eslint-config": "workspace:*",
+    "@nest-boot/eslint-plugin": "workspace:*",
     "@nest-boot/health-check": "workspace:*",
     "@nest-boot/tsconfig": "workspace:*",
     "@nestjs/common": "^10.2.5",

--- a/packages/schedule/package.json
+++ b/packages/schedule/package.json
@@ -26,6 +26,7 @@
   },
   "devDependencies": {
     "@nest-boot/eslint-config": "workspace:*",
+    "@nest-boot/eslint-plugin": "workspace:*",
     "@nest-boot/queue": "workspace:*",
     "@nest-boot/request-context": "workspace:*",
     "@nest-boot/tsconfig": "workspace:*",

--- a/packages/search-engine-postgresql/package.json
+++ b/packages/search-engine-postgresql/package.json
@@ -28,6 +28,7 @@
     "@mikro-orm/postgresql": "^5.8.1",
     "@nest-boot/database": "workspace:*",
     "@nest-boot/eslint-config": "workspace:*",
+    "@nest-boot/eslint-plugin": "workspace:*",
     "@nest-boot/search": "workspace:*",
     "@nest-boot/tsconfig": "workspace:*",
     "@nestjs/common": "^10.2.5",

--- a/packages/search/package.json
+++ b/packages/search/package.json
@@ -24,6 +24,7 @@
     "@mikro-orm/core": "^5.8.1",
     "@nest-boot/database": "workspace:*",
     "@nest-boot/eslint-config": "workspace:*",
+    "@nest-boot/eslint-plugin": "workspace:*",
     "@nest-boot/tsconfig": "workspace:*",
     "@nestjs/common": "^10.2.5",
     "@nestjs/core": "^10.2.5",

--- a/packages/search/src/search.engine.ts
+++ b/packages/search/src/search.engine.ts
@@ -3,11 +3,12 @@ import { type EntityName } from "@mikro-orm/core";
 import { type SearchOptions } from "./interfaces";
 
 export class SearchEngine {
+  // eslint-disable-next-line @typescript-eslint/require-await
   async search<E extends { id: string | number | bigint }>(
-    service: EntityName<E>,
-    query: string,
-    options?: SearchOptions<E>
-  ): Promise<[Array<E["id"]>, number]> {
+    _service: EntityName<E>,
+    _query: string,
+    _options?: SearchOptions<E>,
+  ): Promise<[E["id"][], number]> {
     return [[], 0];
   }
 }

--- a/packages/validator/package.json
+++ b/packages/validator/package.json
@@ -28,6 +28,7 @@
   },
   "devDependencies": {
     "@nest-boot/eslint-config": "workspace:*",
+    "@nest-boot/eslint-plugin": "workspace:*",
     "@nest-boot/i18n": "workspace:*",
     "@nest-boot/tsconfig": "workspace:*",
     "@nestjs/common": "^10.2.5",

--- a/packages/view/package.json
+++ b/packages/view/package.json
@@ -26,6 +26,7 @@
   },
   "devDependencies": {
     "@nest-boot/eslint-config": "workspace:*",
+    "@nest-boot/eslint-plugin": "workspace:*",
     "@nest-boot/tsconfig": "workspace:*",
     "@nestjs/common": "^10.2.5",
     "@nestjs/core": "^10.2.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -557,6 +557,9 @@ importers:
       '@nest-boot/eslint-config':
         specifier: workspace:*
         version: link:../eslint-config
+      '@nest-boot/eslint-plugin':
+        specifier: workspace:*
+        version: link:../eslint-plugin
       '@nest-boot/i18n':
         specifier: workspace:*
         version: link:../i18n
@@ -614,6 +617,9 @@ importers:
       '@nest-boot/eslint-config':
         specifier: workspace:*
         version: link:../eslint-config
+      '@nest-boot/eslint-plugin':
+        specifier: workspace:*
+        version: link:../eslint-plugin
       '@nest-boot/tsconfig':
         specifier: workspace:*
         version: link:../tsconfig
@@ -919,6 +925,9 @@ importers:
       '@nest-boot/eslint-config':
         specifier: workspace:*
         version: link:../eslint-config
+      '@nest-boot/eslint-plugin':
+        specifier: workspace:*
+        version: link:../eslint-plugin
       '@nest-boot/tsconfig':
         specifier: workspace:*
         version: link:../tsconfig
@@ -955,6 +964,9 @@ importers:
       '@nest-boot/eslint-config':
         specifier: workspace:*
         version: link:../eslint-config
+      '@nest-boot/eslint-plugin':
+        specifier: workspace:*
+        version: link:../eslint-plugin
       '@nest-boot/tsconfig':
         specifier: workspace:*
         version: link:../tsconfig
@@ -997,6 +1009,9 @@ importers:
       '@nest-boot/eslint-config':
         specifier: workspace:*
         version: link:../eslint-config
+      '@nest-boot/eslint-plugin':
+        specifier: workspace:*
+        version: link:../eslint-plugin
       '@nest-boot/request-context':
         specifier: workspace:*
         version: link:../request-context
@@ -1115,6 +1130,9 @@ importers:
       '@nest-boot/eslint-config':
         specifier: workspace:*
         version: link:../eslint-config
+      '@nest-boot/eslint-plugin':
+        specifier: workspace:*
+        version: link:../eslint-plugin
       '@nest-boot/tsconfig':
         specifier: workspace:*
         version: link:../tsconfig
@@ -1157,6 +1175,9 @@ importers:
       '@nest-boot/eslint-config':
         specifier: workspace:*
         version: link:../eslint-config
+      '@nest-boot/eslint-plugin':
+        specifier: workspace:*
+        version: link:../eslint-plugin
       '@nest-boot/tsconfig':
         specifier: workspace:*
         version: link:../tsconfig
@@ -1269,6 +1290,9 @@ importers:
       '@nest-boot/eslint-config':
         specifier: workspace:*
         version: link:../eslint-config
+      '@nest-boot/eslint-plugin':
+        specifier: workspace:*
+        version: link:../eslint-plugin
       '@nest-boot/health-check':
         specifier: workspace:*
         version: link:../health-check
@@ -1357,6 +1381,9 @@ importers:
       '@nest-boot/eslint-config':
         specifier: workspace:*
         version: link:../eslint-config
+      '@nest-boot/eslint-plugin':
+        specifier: workspace:*
+        version: link:../eslint-plugin
       '@nest-boot/queue':
         specifier: workspace:*
         version: link:../queue
@@ -1411,6 +1438,9 @@ importers:
       '@nest-boot/eslint-config':
         specifier: workspace:*
         version: link:../eslint-config
+      '@nest-boot/eslint-plugin':
+        specifier: workspace:*
+        version: link:../eslint-plugin
       '@nest-boot/tsconfig':
         specifier: workspace:*
         version: link:../tsconfig
@@ -1463,6 +1493,9 @@ importers:
       '@nest-boot/eslint-config':
         specifier: workspace:*
         version: link:../eslint-config
+      '@nest-boot/eslint-plugin':
+        specifier: workspace:*
+        version: link:../eslint-plugin
       '@nest-boot/search':
         specifier: workspace:*
         version: link:../search
@@ -1520,6 +1553,9 @@ importers:
       '@nest-boot/eslint-config':
         specifier: workspace:*
         version: link:../eslint-config
+      '@nest-boot/eslint-plugin':
+        specifier: workspace:*
+        version: link:../eslint-plugin
       '@nest-boot/i18n':
         specifier: workspace:*
         version: link:../i18n
@@ -1572,6 +1608,9 @@ importers:
       '@nest-boot/eslint-config':
         specifier: workspace:*
         version: link:../eslint-config
+      '@nest-boot/eslint-plugin':
+        specifier: workspace:*
+        version: link:../eslint-plugin
       '@nest-boot/tsconfig':
         specifier: workspace:*
         version: link:../tsconfig

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1079,6 +1079,9 @@ importers:
       '@nest-boot/eslint-config':
         specifier: workspace:*
         version: link:../eslint-config
+      '@nest-boot/eslint-plugin':
+        specifier: workspace:*
+        version: link:../eslint-plugin
       '@nest-boot/request-context':
         specifier: workspace:*
         version: link:../request-context


### PR DESCRIPTION
This pull request includes changes to import RequestContext in modules that strongly depend on it. This ensures that the modules have access to the RequestContext object and can make use of its functionality.